### PR TITLE
feat: add Download JSON button to preview section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 Here's a professional **README.md** file for your XML-to-JSON converter project with S3 integration:
 
-```markdown
 # DataBridge: XML to JSON Converter with AWS S3
 
 ![Node.js](https://img.shields.io/badge/Node.js-18.x-green)

--- a/public/index.html
+++ b/public/index.html
@@ -148,6 +148,11 @@
           <a href="${result.downloadUrl}" target="_blank" id="downloadLink">JSON</a>
 
           <p>(expires in <span class="countdown" id="countdown">5:00</span>):</p>
+
+          <button id="downloadJsonBtn" style="margin-top: 10px: padding: 10px 20px; background-color: #2980b9; color: white; border: none; border-radium: 4px;">
+             Download JSON
+          </button>
+          
           <h4>Preview:</h4>
           <pre>${JSON.stringify(result.jsonPreview, null, 2)}</pre>
         `;

--- a/public/index.html
+++ b/public/index.html
@@ -157,6 +157,18 @@
           <pre>${JSON.stringify(result.jsonPreview, null, 2)}</pre>
         `;
 
+        document.getElementById('downloadJsonBtn').addEventListener('click', () => {
+          const jsonData = JSON.stringify(result.jsonPreview, null, 2);
+          const blob = new Blob([jsonData], { type: 'application/json' });
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'converted.json';
+          a.click();
+          URL.revokeObjectURL(url); 
+        });
+
+
         let timeLeft = 300;
         const timer = setInterval(() => {
           timeLeft--;


### PR DESCRIPTION
Adds a "Download JSON" button below the converted file preview.
This button generates a downloadable file from the JSON output using a Blob and triggers a client-side download.
Resolves UI issue where users had no direct download option


Closes #3 